### PR TITLE
Add AWS Copilot CLI

### DIFF
--- a/scripts/projects.yml
+++ b/scripts/projects.yml
@@ -81,7 +81,8 @@ kinesis:
   - https://github.com/awslabs/kinesis-log4j-appender
 elastic-container-services:
   - https://github.com/aws/amazon-ecs-agent
-  - https://github.com/aws/amazon-ecs-init
+  - https://github.com/aws/amazon-ecs-init  
+  - https://github.com/aws/copilot-cli
   - https://github.com/blox/blox
   - https://github.com/awslabs/ecs-blue-green-deployment
   - https://github.com/awslabs/ecs-cloudwatch-logs


### PR DESCRIPTION
This change adds the AWS Copilot CLI tool to the list of ECS tools 👍 
https://aws.github.io/copilot-cli/
https://github.com/aws/copilot-cli

Hope folks find it useful!