### PR TITLE
Add mfaprof

### DIFF
--- a/scripts/projects.yml
+++ b/scripts/projects.yml
@@ -168,6 +168,7 @@ iam:
   urls:
     - https://github.com/udondan/iam-floyd
     - https://github.com/Noovolari/leapp
+		- https://github.com/gevial/mfaprof
 testing:
   urls:
     - https://github.com/spulec/moto


### PR DESCRIPTION
mfaprof is a tool to manage MFA-protected AWS CLI access at scale.
Adding it to `iam` section, seems to make sense.